### PR TITLE
Linux fixes

### DIFF
--- a/.dialogrc
+++ b/.dialogrc
@@ -23,9 +23,6 @@ tab_len = 0
 # Make tab-traversal for checklist, etc., include the list.
 visit_items = OFF
 
-# Show scrollbar in dialog boxes?
-use_scrollbar = ON
-
 # Shadow dialog boxes? This also turns on color.
 use_shadow = ON
 

--- a/README.md
+++ b/README.md
@@ -24,20 +24,34 @@ This repository is a work in progress and is made purely to simplify the interac
 
 ## Executing Program
 
-To run the base script, open up a terminal window and navigate to the directory where you cloned the repo and run the following command:
+To run the base script, open up a terminal window and navigate to the directory where you cloned the repo. 
+Run the following command to make the script executable:
 
 ```
-sh quai.sh
+chmod +x quai.sh
+```
+You may need to run `sudo chmod +x quai.sh` if you get a permission denied error. You'll only need to do this once for each script.
+
+Then run the following command to execute the script:
+
+```
+./quai.sh
 ```
 
 The base script interface will look like this:
 
 ![quai.sh](./Screenshots/quaish.png)
 
-To run the advanced script, in the same directory, run the following command:
+To run the advanced script, in the same directory, run the following command to make the script executable:
 
 ```
-sh quai-admin.sh
+chmod +x quai-admin.sh
+```
+
+Then run the following command to execute the script:
+
+```
+./quai-admin.sh
 ```
 
 The advanced script interface will look like this:

--- a/quai-admin.sh
+++ b/quai-admin.sh
@@ -84,20 +84,10 @@ else
             --no-collapse \
             --infobox "\nGenerating binaries.\n \nPlease wait. " 7 28
 
-            # Ask user to input wallet addresses and replace them in the network.env file
-            dialog --title "Installation" \
-            --no-collapse \
-            --msgbox "\nPlease enter your 13 Quai addresses.\n \nPress OK to continue." 0 0
-            
-            ## Placeholder for new copy paste network.env thing
-            dialog --title "Installation" \
-            --no-collapse \
-            --msgbox "\nPLACEHOLDER" 0 0
-
             #Inform user node is configured
             dialog --title "Installation" \
             --no-collapse \
-            --msgbox "\nNode and mining addresses configured.\n \nPress OK to continue." 0 0
+            --msgbox "\nNode configured.\n \nPress OK to continue." 0 0
 
             # Clone into quai-manager
             cd $HOME/$MAIN_DIR
@@ -185,7 +175,7 @@ while true; do
   case $exit_status in
     $DIALOG_CANCEL)
       # Verify the user wants to stop their node and manager
-      dialog --title "Alert" --colors --yesno "\nExit the program?\n \n\Z1This will stop your node and miner.\Zn" 0 0
+      dialog --title "Alert" --colors --yesno "\nExit the Quai Hardware Manager?\n \n\Z1This will stop your node and miner.\Zn" 0 0
       response=$?
       EXIT="False"
       case $response in
@@ -203,13 +193,13 @@ while true; do
           --no-collapse \
           --infobox "\nStopping Node and/or Manager.\n \nPlease wait."  0 0
           clear
-        echo "Program terminated."
+        echo "Quai Hardware Manager stopped."
         exit
       fi
       ;;
     $DIALOG_ESC)
       # Verify the user wants to stop their node and manager
-      dialog --yesno "\nExit the program?\n \n\Z1This will stop your node and miner.\Zn" 0 0
+      dialog --title "Alert" --yesno "\nExit the Quai Hardware Manager?\n \n\Z1This will stop your node and miner.\Zn" 0 0
       response=$?
       EXIT="False"
       case $response in
@@ -227,7 +217,7 @@ while true; do
           --no-collapse \
           --infobox "\nStopping Node and/or Manager.\n \nPlease wait."  0 0
           clear
-        echo "Program terminated."
+        echo "Quai Hardware Manager stopped."
         exit
       fi
       ;;

--- a/quai.sh
+++ b/quai.sh
@@ -22,7 +22,7 @@ while true; do
     for i in "${arr[@]}"; do
         if [ -d "$i" ]; then
             INSTALLED="True"
-            INSTALL_DISPLAY="Installed ✔"
+            INSTALL_DISPLAY="-- Installed --"
         else
             INSTALLED=Install
             INSTALL_DISPLAY="Install"
@@ -47,7 +47,7 @@ while true; do
     # Check if full node is running
     if pgrep -x "$node_process_name" >/dev/null; then
         ISRUNNING="True"
-        STARTFULLNODE="Full Node - Running ✔"
+        STARTFULLNODE="Full Node - Running"
     else
         ISRUNNING="False"
         STARTFULLNODE="Start Full Node"
@@ -56,7 +56,7 @@ while true; do
     # Check if manager is running
     if pgrep -x "$manager_process_name" >/dev/null; then
         ISMINING="True"
-        STARTMINING="Manager - Running ✔"
+        STARTMINING="Manager - Running"
     else
         ISMINING="False"
         STARTMINING="Start Manager"
@@ -89,12 +89,10 @@ while true; do
           1) EXIT="False";;
           255) EXIT="False";;
       esac
-      if $EXIT; then
+      if [ $EXIT = "True" ]; then
           #If user chooses stop, kill full node
-          cd $HOME/quainetwork/quai-manager
-          make stop>/dev/null 2>&1
-          cd $HOME/quainetwork/go-quai
-          make stop>/dev/null 2>&1 | \
+          pkill -f quai-manager
+          pkill -f go-quai | \
           dialog --title "Stop" \
           --no-collapse \
           --infobox "\nStopping Full-Node and/or Manager. Please wait."  0 0
@@ -113,11 +111,10 @@ while true; do
           1) EXIT="False";;
           255) EXIT="False";;
       esac
-      if $EXIT; then
+      if [ $EXIT = "True" ]; then
           #If user chooses stop, kill full node
-          cd $HOME/quainetwork/quai-manager
-          make stop>/dev/null 2>&1
-          cd $HOME/quainetwork/go-quai
+          pkill -f quai-manager
+          pkill -f go-quai | \
           make stop>/dev/null 2>&1 | \
           dialog --title "Stop" \
           --no-collapse \
@@ -131,7 +128,7 @@ while true; do
   case $selection in
     1 )
       #If installed, redirect back to menu
-      if $INSTALLED; then
+      if [ $INSTALLED = "True" ]; then
         dialog --title "Alert" \
         --no-collapse \
         --msgbox  "\ngo-quai and quai-manager have already been installed." 0 0
@@ -220,7 +217,7 @@ while true; do
       ;;
     3 )
         #If node is running, redirect back to menu
-        if $ISRUNNING; then
+        if [ $ISRUNNING = "True" ]; then
             dialog --title "Alert" \
             --no-collapse \
             --msgbox  "\nFull-Node is already running." 0 0
@@ -302,11 +299,11 @@ while true; do
       ;;
     4 )
         #If manager is running, redirect back to menu
-        if $ISMINING; then
+        if [ $ISMINING = "True" ]; then
             dialog --title "Alert" \
             --no-collapse \
             --msgbox  "\nManager is already running." 0 0
-        elif ! $ISRUNNING; then
+        elif [ $ISRUNNING = "False" ]; then
             dialog --title "Alert" \
             --no-collapse \
             --msgbox  "\nPlease start your Full-Node before starting the Manager." 0 0
@@ -324,8 +321,6 @@ while true; do
             REGION=$(($REGION-1))
             ZONE=$(($ZONE-1))
             cd $HOME/quainetwork/quai-manager && make run-mine-background region=$REGION zone=$ZONE
-            ISMINING="True"
-            ISRUNNING="False"
 
             dialog --title "Alert" \
             --no-collapse \
@@ -358,28 +353,28 @@ while true; do
             1) STOP="False";;
             255) STOP="False";;
         esac
-        if $STOP; then
+        if [ $STOP = "True" ]; then
             #If user chooses stop, kill full node
             cd $HOME/quainetwork/quai-manager
-            make stop>/dev/null 2>&1
+            make stop
             cd $HOME/quainetwork/go-quai
-            make stop>/dev/null 2>&1 | \
+            make stop | \
             dialog --title "Stop" \
             --no-collapse \
             --infobox "\nStopping Full-Node and/or Manager. Please wait."  0 0
             dialog --title "Stop" \
-            --no-collapse \
-            --msgbox "\nFull-Node and/or Manager stopped. Press OK to return to the menu." 0 0
-        fi
+            --no-cancel \
+            --pause "\nFull-Node and/or Manager stopped. Press OK to return to the menu." 10 40 2
+         fi
       ;;
     6 )
-        if ! $NODELOGS; then
+        if [ $NODELOGS = "False" ]; then
             dialog --title "Alert" \
             --no-collapse \
             --msgbox "\nPlease start your full-node before viewing nodelogs." 0 0
         else
             #Print nodelogs
-            cd
+            cd $HOME
             LOCATION=$(dialog --nocancel --menu "In which location would you like to view nodelogs?" 0 0 13 \
                     1 "Prime" \
                     2 "Cyprus" \
@@ -441,7 +436,7 @@ while true; do
         fi
       ;;
     7 )
-        if ! $MININGLOGS; then
+        if [ $MININGLOGS = "False"]; then
             dialog --title "Alert" \
             --no-collapse \
             --msgbox "\nPlease start your manager before viewing manager logs." 0 0

--- a/quai.sh
+++ b/quai.sh
@@ -3,13 +3,15 @@
 DIALOG_CANCEL=1
 DIALOG_ESC=255
 STYLECONFIG=~/.dialogrc
+MAIN_DIR="quainetwork"
+NODE_PROCESS="go-quai"
+MANAGER_PROCESS="quai-manager"
 
 if [ -f "$STYLECONFIG" ]; then
     echo "Styling config found."
     if cmp --silent "$STYLECONFIG" ".dialogrc"; then
-        echo "Styling config is up to date."
+        :
     else
-        echo "Styling config is out of date."
         cp .dialogrc ~/.dialogrc
     fi
 else
@@ -17,436 +19,486 @@ else
     cp .dialogrc ~/.dialogrc
 fi
 
-while true; do
-    arr=("$HOME/quainetwork/go-quai" "$HOME/quainetwork/quai-manager")
-    for i in "${arr[@]}"; do
-        if [ -d "$i" ]; then
-            INSTALLED="True"
-            INSTALL_DISPLAY="-- Installed --"
-        else
-            INSTALLED=Install
-            INSTALL_DISPLAY="Install"
-        fi
-    done
+if command -v go 2>/dev/null; then
+    :
+else
+    dialog --title "Installation" --msgbox "\nGolang is not installed. Please install to run this script." 0 0
+    echo "Golang can be installed at https://go.dev/doc/install"
+    exit
+fi
 
-    if [ -d "$HOME/quainetwork/go-quai/nodelogs" ]; then
+if command -v git 2>/dev/null; then
+    :
+else
+    dialog --title "Installation" --msgbox "\nGit is not installed. Please install to run this script." 0 0
+    echo "Git can be installed at https://github.com/git-guides/install-git"
+    exit
+fi
+
+# Check installation status, if not found, prompt the user to install.
+if [[ -d "$HOME/$MAIN_DIR/go-quai" && -d "$HOME/$MAIN_DIR/quai-manager" ]]; then
+    :
+else
+    # Check if user has configured wallet addresses
+    dialog --title "Installation" --yesno "\nHave you configured 13 Quai addresses? You'll need them to run a node and mine." 0 0
+    response=$?
+    case $response in
+        0)  : ;;
+        1)
+            # Inform user to configure addresses
+            dialog --title "Installation" --msgbox "\nPlease configure your wallet addresses before continuing." 0 0
+            echo "You can set up addresses here: https://docs.quai.network/use-quai/wallets/quaisnap"
+            exit
+            ;;
+        255)
+            exit
+            ;;
+    esac
+
+    # Check if user wants to install
+    dialog --title "Installation" --yesno "\nThis will install go-quai and quai-manager in the home directory. Continue?" 0 0
+    response=$?
+    case $response in
+        0) 
+            # Create directory
+            cd $HOME
+            mkdir $MAIN_DIR
+            # Clone into go-quai
+            cd $MAIN_DIR
+            git clone https://github.com/dominant-strategies/go-quai>/dev/null 2>&1 | \
+            dialog --title "Installation" \
+            --no-collapse \
+            --infobox "\nInstalling Node. Please wait."  7 28
+            
+            #Inform user node is installed
+            dialog --title "Installation" \
+            --no-collapse \
+            --msgbox "\nNode installed. Press OK to continue." 7 28
+
+            #Configure go-quai
+            cd $HOME/$MAIN_DIR/go-quai
+            cp network.env.dist network.env
+            make go-quai>/dev/null 2>&1 | 
+            dialog --title "Installation" \
+            --no-collapse \
+            --infobox "\nGenerating binaries. Please wait. " 7 28
+
+            # Ask user to input wallet addresses and replace them in the network.env file
+            dialog --title "Installation" \
+            --no-collapse \
+            --msgbox "\nPlease enter your 13 Quai addresses. Press OK to continue." 0 0
+            
+            ## Placeholder for new copy paste network.env thing
+            dialog --title "Installation" \
+            --no-collapse \
+            --msgbox "\nPLACEHOLDER" 0 0
+
+            #Inform user node is configured
+            dialog --title "Installation" \
+            --no-collapse \
+            --msgbox "\nNode and mining addresses configured. Press OK to continue." 0 0
+
+            # Clone into quai-manager
+            cd $HOME/$MAIN_DIR
+            git clone https://github.com/dominant-strategies/quai-manager>/dev/null 2>&1 | \
+            dialog --title "Installation" \
+            --no-collapse \
+            --infobox "\nInstalling Manager. Please wait."  7 28
+            
+            #Inform user manager is installed
+            dialog --title "Installation" \
+            --no-collapse \
+            --msgbox "\nManager installed. Press OK to continue." 7 28
+
+            #Configure quai-manager
+            cd $HOME/$MAIN_DIR/quai-manager
+            make quai-manager>/dev/null 2>&1 | \
+            dialog --title "Installation" 
+            --no-collapse \
+            --infobox "\nGenerating binaries. Please wait. " 7 28
+
+            #Inform user manager is configured
+            dialog --title "Installation" \
+            --no-collapse \
+            --msgbox "\nManager configured. Installation complete." 0 0
+            ;;
+        1) 
+            echo "Installation cancelled."
+            exit ;;
+        255) 
+            echo "Installation cancelled."
+            exit ;;
+    esac
+fi
+
+while true; do
+    # Check if node logs exist (psuedo-check to see if the node has been started before)
+    if [ -d "$HOME/$MAIN_DIR/go-quai/nodelogs" ]; then
         NODELOGS="True"
     else
         NODELOGS="False"
     fi
 
-    if [ -d "$HOME/quainetwork/quai-manager/logs" ]; then
+    # Check if manager logs exist (psuedo-check to see if the manager has been started before)
+    if [ -d "$HOME/$MAIN_DIR/quai-manager/logs" ]; then
         MININGLOGS="True"
     else
         MININGLOGS="False"
     fi
 
-    node_process_name="go-quai"
-    manager_process_name="quai-manager"
-
-    # Check if full node is running
-    if pgrep -x "$node_process_name" >/dev/null; then
+    # Check if node is running
+    if pgrep -x "$NODE_PROCESS">/dev/null 2>&1; then
         ISRUNNING="True"
-        STARTFULLNODE="Full Node - Running"
+        STARTFULLNODE="Node - \Z2Running\Zn"
     else
         ISRUNNING="False"
-        STARTFULLNODE="Start Full Node"
+        STARTFULLNODE="Start Node - \Z1Stopped\Zn"
     fi
 
     # Check if manager is running
-    if pgrep -x "$manager_process_name" >/dev/null; then
+    if pgrep -x "$MANAGER_PROCESS">/dev/null 2>&1; then
         ISMINING="True"
-        STARTMINING="Manager - Running"
+        STARTMINING="Manager - \Z2Running\Zn"
     else
         ISMINING="False"
-        STARTMINING="Start Manager"
+        STARTMINING="Start Manager - \Z1Stopped\Zn"
     fi
 
-  exec 3>&1
-  selection=$(dialog \
-    --backtitle "Quai Hardware Manager" \
-    --clear \
-    --cancel-label "EXIT" \
-    --menu "Select an Option:" 14 50 10 \
-    "1" "$INSTALL_DISPLAY" \
-    "2" "Update" \
-    "3" "$STARTFULLNODE" \
-    "4" "$STARTMINING" \
-    "5" "Stop" \
-    "6" "Print Node Logs" \
-    "7" "Print Miner Logs" \
-    2>&1 1>&3)
-  exit_status=$?
-  exec 3>&-
-  case $exit_status in
-    $DIALOG_CANCEL)
-      # Verify the user wants to stop their node and manager
-      dialog --title "Alert" --yesno "\nExit the program? This will stop your node and miner." 0 0
-      response=$?
-      EXIT="False"
-      case $response in
-          0) EXIT="True";;
-          1) EXIT="False";;
-          255) EXIT="False";;
-      esac
-      if [ $EXIT = "True" ]; then
-          #If user chooses stop, kill full node
-          pkill -f quai-manager
-          pkill -f go-quai | \
-          dialog --title "Stop" \
-          --no-collapse \
-          --infobox "\nStopping Full-Node and/or Manager. Please wait."  0 0
-          clear
-        echo "Program terminated."
-        exit
-      fi
-      ;;
-    $DIALOG_ESC)
-      # Verify the user wants to stop their node and manager
-      dialog --yesno "\nExit the program? This will stop your node and miner." 0 0
-      response=$?
-      EXIT="False"
-      case $response in
-          0) EXIT="True";;
-          1) EXIT="False";;
-          255) EXIT="False";;
-      esac
-      if [ $EXIT = "True" ]; then
-          #If user chooses stop, kill full node
-          pkill -f quai-manager
-          pkill -f go-quai | \
-          make stop>/dev/null 2>&1 | \
-          dialog --title "Stop" \
-          --no-collapse \
-          --infobox "\nStopping Full-Node and/or Manager. Please wait."  0 0
-          clear
-        echo "Program terminated."
-        exit
-      fi
-      ;;
-  esac
-  case $selection in
-    1 )
-      #If installed, redirect back to menu
-      if [ $INSTALLED = "True" ]; then
-        dialog --title "Alert" \
-        --no-collapse \
-        --msgbox  "\ngo-quai and quai-manager have already been installed." 0 0
-      else
-        # Move to home directory
-        cd
-        MAIN_DIR="quainetwork"
-        mkdir $MAIN_DIR
-
-        dialog --yesno "\nThis will install go-quai and quai-manager in the HOME directory. Continue?" 0 0
-        response=$?
-        case $response in
-            0) 
-                # Clone into go-quai
-                cd $MAIN_DIR
-                git clone https://github.com/dominant-strategies/go-quai>/dev/null 2>&1 | \
-                dialog --title "Installation" \
-                --no-collapse \
-                --infobox "\nInstalling Full-Node. Please wait."  7 28
-
-                dialog --title "Installation" \
-                --no-collapse \
-                --msgbox "\nFull-Node installed. Press OK to continue." 7 28
-
-                #Configure go-quai
-                cd $HOME/$MAIN_DIR/go-quai
-                cp network.env.dist network.env
-                make go-quai>/dev/null 2>&1 | 
-                dialog --title "Installation" \
-                --no-collapse \
-                --infobox "\nGenerating binaries. Please wait. " 7 28
-
-                dialog --title "Installation" \
-                --no-collapse \
-                --msgbox "\nFull-Node configured. Press OK to continue." 7 28
-
-                # Clone into quai-manager
-                cd $HOME/$MAIN_DIR
-                git clone https://github.com/dominant-strategies/quai-manager>/dev/null 2>&1 | \
-                dialog --title "Installation" \
-                --no-collapse \
-                --infobox "\nInstalling Manager. Please wait."  7 28
-
-                dialog --title "Installation" \
-                --no-collapse \
-                --msgbox "\nManager installed. Press OK to continue." 7 28
-
-                #Configure quai-manager
-                cd $HOME/$MAIN_DIR/quai-manager
-                make quai-manager>/dev/null 2>&1 | \
-                dialog --title "Installation" 
-                --no-collapse \
-                --infobox "\nGenerating binaries. Please wait. " 7 28
-
-                dialog --title "Installation" \
-                --no-collapse \
-                --msgbox "\nManager configured. Installation complete. Press OK to return to the menu." 0 0
-                ;;
-            1) INSTALL="False";;
-            255) INSTALL="False";;
-        esac
-      fi
-      ;;
-    2 )
-        # Update go-quai
-        cd $HOME/quainetwork/go-quai
-        git pull>/dev/null 2>&1 && make go-quai>/dev/null 2>&1 | \
-        dialog --title "Update" \
-        --no-collapse \
-        --infobox "\nUpdating Full-Node. Please wait."  7 28
-        
-        dialog --title "Update" \
-        --no-collapse \
-        --msgbox "\nFull-Node updated. Press OK to continue." 7 28
-
-        # Update quai-manager
-        cd $HOME/quainetwork/quai-manager
-        git pull>/dev/null 2>&1 && make quai-manager>/dev/null 2>&1 | \
-        dialog --title "Update" \
-        --no-collapse \
-        --infobox "\nUpdating Manager. Please wait."  7 28
-
-        dialog --title "Update" \
-        --no-collapse \
-        --msgbox "\nManager updated. Press OK to return to the menu." 0 0
-      ;;
-    3 )
-        #If node is running, redirect back to menu
-        if [ $ISRUNNING = "True" ]; then
-            dialog --title "Alert" \
-            --no-collapse \
-            --msgbox  "\nFull-Node is already running." 0 0
-        else
-            # Start go-quai
-            cd $HOME/quainetwork/go-quai && make run-all
-            
-            # Ask the user if they would like to view nodelogs
-            dialog --title "Alert" \
-            --no-collapse \
-            --yesno  "\nFull-Node started. Would you like to view the last 40 lines of your nodelogs?" 0 0
-            response=$?
-            case $response in
-                0) 
-                    #Print nodelogs
-                    cd
-                    LOCATION=$(dialog --nocancel --menu "In which location would you like to view nodelogs?" 0 0 13 \
-                            1 "Prime" \
-                            2 "Cyprus" \
-                            3 "Paxos" \
-                            4 "Hydra" \
-                            5 "Cyprus-1" \
-                            6 "Cyprus-2" \
-                            7 "Cyprus-3" \
-                            8 "Paxos-1" \
-                            9 "Paxos-2" \
-                            10 "Paxos-3" \
-                            11 "Hydra-1" \
-                            12 "Hydra-2" \
-                            13 "Hydra-3" 3>&1 1>&2 2>&3 3>&- )
-                    case $LOCATION in
-                        1) 
-                            FILE="quainetwork/go-quai/nodelogs/prime.log"
-                            ;;
-                        2)
-                            FILE="quainetwork/go-quai/nodelogs/region-0.log"
-                            ;;
-                        3)
-                            FILE="quainetwork/go-quai/nodelogs/region-1.log"
-                            ;;
-                        4)
-                            FILE="quainetwork/go-quai/nodelogs/region-2.log"
-                            ;;
-                        5)
-                            FILE="quainetwork/go-quai/nodelogs/zone-0-0.log"
-                            ;;
-                        6)
-                            FILE="quainetwork/go-quai/nodelogs/zone-0-1.log"
-                            ;;
-                        7)
-                            FILE="quainetwork/go-quai/nodelogs/zone-0-2.log"
-                            ;;
-                        8)
-                            FILE="quainetwork/go-quai/nodelogs/zone-1-0.log"
-                            ;;
-                        9)
-                            FILE="quainetwork/go-quai/nodelogs/zone-1-1.log"
-                            ;;
-                        10)
-                            FILE="quainetwork/go-quai/nodelogs/zone-1-2.log"
-                            ;;
-                        11)
-                            FILE="quainetwork/go-quai/nodelogs/zone-2-0.log"
-                            ;;
-                        12)
-                            FILE="quainetwork/go-quai/nodelogs/zone-2-1.log"
-                            ;;
-                        13)
-                            FILE="quainetwork/go-quai/nodelogs/zone-2-2.log"
-                            ;;
-                    esac
-                    result=`tail -40 $FILE`
-                    dialog --cr-wrap --title "$FILE" --no-collapse --msgbox "\n$result" 30 90
-                    ;;
-                1) clear;;
-                255) clear;;
-            esac
-        fi
-      ;;
-    4 )
-        #If manager is running, redirect back to menu
-        if [ $ISMINING = "True" ]; then
-            dialog --title "Alert" \
-            --no-collapse \
-            --msgbox  "\nManager is already running." 0 0
-        elif [ $ISRUNNING = "False" ]; then
-            dialog --title "Alert" \
-            --no-collapse \
-            --msgbox  "\nPlease start your Full-Node before starting the Manager." 0 0
-        else
-            REGION=$(dialog --nocancel --menu "Which regiond would you like to mine?" 0 0 3 \
-                1 "Cyprus" \
-                2 "Paxos" \
-                3 "Hydra" 3>&1 1>&2 2>&3 3>&- )
-            ZONE=$(dialog --nocancel --menu "Which region would you like to mine?" 0 0 3 \
-                1 "Zone-0" \
-                2 "Zone-1" \
-                3 "Zone-2" 3>&1 1>&2 2>&3 3>&- )
-
-            # Start go-quai
-            REGION=$(($REGION-1))
-            ZONE=$(($ZONE-1))
-            cd $HOME/quainetwork/quai-manager && make run-mine-background region=$REGION zone=$ZONE
-
-            dialog --title "Alert" \
-            --no-collapse \
-            --msgbox  "Manager started in: \nRegion: $REGION \nZone: $ZONE" 0 0
-            
-            # Ask the user if they would like to view nodelogs
-            dialog --title "Alert" \
-            --no-collapse \
-            --yesno  "\nManager started. Would you like to view the last 40 lines of your miner logs?" 0 0
-            response=$?
-            case $response in
-                0) 
-                    # Print nodelogs
-                    cd
-                    result=`tail -40 quainetwork/quai-manager/logs/quai-manager.log`
-                    dialog --cr-wrap --title "quainetwork/quai-manger/logs/quai-manager.log" --msgbox "\n$result" 30 90
-                    ;;
-                1) clear;;
-                255) clear;;
-            esac
-        fi
-      ;;
-    5 )
+    exec 3>&1
+    selection=$(dialog \
+        --backtitle "Quai Hardware Manager" \
+        --clear \
+        --colors \
+        --cancel-label "EXIT" \
+        --menu "Select an Option:" 14 50 10 \
+        "1" "$STARTFULLNODE" \
+        "2" "$STARTMINING" \
+        "3" "Stop" \
+        "4" "Update" \
+        "5" "Node Logs" \
+        "6" "Miner Logs" \
+        2>&1 1>&3)
+    exit_status=$?
+    exec 3>&-
+    case $exit_status in
+        $DIALOG_CANCEL)
         # Verify the user wants to stop their node and manager
-        dialog --title "Alert" --yesno "\nAre you sure you want to stop the Full Node and/or Manager?" 0 0
+        dialog --title "Alert" --yesno "\nExit the program? This will stop your node and miner." 0 0
         response=$?
-        STOP="False"
+        EXIT="False"
         case $response in
-            0) STOP="True";;
-            1) STOP="False";;
-            255) STOP="False";;
+            0) EXIT="True";;
+            1) EXIT="False";;
+            255) EXIT="False";;
         esac
-        if [ $STOP = "True" ]; then
-            #If user chooses stop, kill full node
-            cd $HOME/quainetwork/quai-manager
-            make stop
-            cd $HOME/quainetwork/go-quai
-            make stop | \
+        if [ $EXIT = "True" ]; then
+            #If user chooses stop, kill node
+            cd $HOME/$MAIN_DIR/quai-manager
+            make stop>/dev/null 2>&1
+            cd $HOME/$MAIN_DIR/go-quai
+            make stop>/dev/null 2>&1 | \
             dialog --title "Stop" \
             --no-collapse \
-            --infobox "\nStopping Full-Node and/or Manager. Please wait."  0 0
+            --infobox "\nStopping Node and/or Manager. Please wait."  0 0
+            clear
+            echo "Program terminated."
+            exit
+        fi
+        ;;
+        $DIALOG_ESC)
+        # Verify the user wants to stop their node and manager
+        dialog --yesno "\nExit the program? This will stop your node and miner." 0 0
+        response=$?
+        EXIT="False"
+        case $response in
+            0) EXIT="True";;
+            1) EXIT="False";;
+            255) EXIT="False";;
+        esac
+        if [ $EXIT = "True" ]; then
+            #If user chooses stop, kill node
+            cd $HOME/$MAIN_DIR/quai-manager
+            make stop>/dev/null 2>&1
+            cd $HOME/$MAIN_DIR/go-quai
+            make stop>/dev/null 2>&1 | \
             dialog --title "Stop" \
-            --no-cancel \
-            --pause "\nFull-Node and/or Manager stopped. Press OK to return to the menu." 10 40 2
-         fi
-      ;;
-    6 )
-        if [ $NODELOGS = "False" ]; then
-            dialog --title "Alert" \
             --no-collapse \
-            --msgbox "\nPlease start your full-node before viewing nodelogs." 0 0
-        else
-            #Print nodelogs
-            cd $HOME
-            LOCATION=$(dialog --nocancel --menu "In which location would you like to view nodelogs?" 0 0 13 \
-                    1 "Prime" \
-                    2 "Cyprus" \
-                    3 "Paxos" \
-                    4 "Hydra" \
-                    5 "Cyprus-1" \
-                    6 "Cyprus-2" \
-                    7 "Cyprus-3" \
-                    8 "Paxos-1" \
-                    9 "Paxos-2" \
-                    10 "Paxos-3" \
-                    11 "Hydra-1" \
-                    12 "Hydra-2" \
-                    13 "Hydra-3" 3>&1 1>&2 2>&3 3>&- )
-            dialog --nocancel --pause "This will show the last 40 lines of your nodelogs. Press OK to continue." 10 40 2
-            case $LOCATION in
-                1) 
-                    FILE="quainetwork/go-quai/nodelogs/prime.log"
-                    ;;
-                2)
-                    FILE="quainetwork/go-quai/nodelogs/region-0.log"
-                    ;;
-                3)
-                    FILE="quainetwork/go-quai/nodelogs/region-1.log"
-                    ;;
-                4)
-                    FILE="quainetwork/go-quai/nodelogs/region-2.log"
-                    ;;
-                5)
-                    FILE="quainetwork/go-quai/nodelogs/zone-0-0.log"
-                    ;;
-                6)
-                    FILE="quainetwork/go-quai/nodelogs/zone-0-1.log"
-                    ;;
-                7)
-                    FILE="quainetwork/go-quai/nodelogs/zone-0-2.log"
-                    ;;
-                8)
-                    FILE="quainetwork/go-quai/nodelogs/zone-1-0.log"
-                    ;;
-                9)
-                    FILE="quainetwork/go-quai/nodelogs/zone-1-1.log"
-                    ;;
-                10)
-                    FILE="quainetwork/go-quai/nodelogs/zone-1-2.log"
-                    ;;
-                11)
-                    FILE="quainetwork/go-quai/nodelogs/zone-2-0.log"
-                    ;;
-                12)
-                    FILE="quainetwork/go-quai/nodelogs/zone-2-1.log"
-                    ;;
-                13)
-                    FILE="quainetwork/go-quai/nodelogs/zone-2-2.log"
-                    ;;
+            --infobox "\nStopping Node and/or Manager. Please wait."  0 0
+            clear
+            echo "Program terminated."
+            exit
+        fi
+        ;;
+    esac
+    case $selection in
+        1 )
+            #If node is running, redirect back to menu
+            if [ $ISRUNNING = "True" ]; then
+                dialog --title "Alert" \
+                --no-collapse \
+                --msgbox  "\nNode is already running." 0 0
+            else
+                
+
+                # Start go-quai
+                cd $HOME/$MAIN_DIR/go-quai && make run-all>/dev/null 2>&1 | \
+                dialog --title "Node" \
+                --no-collapse \
+                --infobox "\nStarting Node. Please wait." 0 0
+                
+                # Ask the user if they would like to view nodelogs
+                dialog --title "Alert" \
+                --no-collapse \
+                --yesno  "\nNode started. Would you like to view the last 40 lines of your nodelogs?" 0 0
+                response=$?
+                case $response in
+                    0) 
+                        #Print nodelogs
+                        cd
+                        LOCATION=$(dialog --nocancel --menu "In which location would you like to view nodelogs?" 0 0 13 \
+                                1 "Prime" \
+                                2 "Cyprus" \
+                                3 "Paxos" \
+                                4 "Hydra" \
+                                5 "Cyprus-1" \
+                                6 "Cyprus-2" \
+                                7 "Cyprus-3" \
+                                8 "Paxos-1" \
+                                9 "Paxos-2" \
+                                10 "Paxos-3" \
+                                11 "Hydra-1" \
+                                12 "Hydra-2" \
+                                13 "Hydra-3" 3>&1 1>&2 2>&3 3>&- )
+                        case $LOCATION in
+                            1) 
+                                FILE="$MAIN_DIR/go-quai/nodelogs/prime.log"
+                                ;;
+                            2)
+                                FILE="$MAIN_DIR/go-quai/nodelogs/region-0.log"
+                                ;;
+                            3)
+                                FILE="$MAIN_DIR/go-quai/nodelogs/region-1.log"
+                                ;;
+                            4)
+                                FILE="$MAIN_DIR/go-quai/nodelogs/region-2.log"
+                                ;;
+                            5)
+                                FILE="$MAIN_DIR/go-quai/nodelogs/zone-0-0.log"
+                                ;;
+                            6)
+                                FILE="$MAIN_DIR/go-quai/nodelogs/zone-0-1.log"
+                                ;;
+                            7)
+                                FILE="$MAIN_DIR/go-quai/nodelogs/zone-0-2.log"
+                                ;;
+                            8)
+                                FILE="$MAIN_DIR/go-quai/nodelogs/zone-1-0.log"
+                                ;;
+                            9)
+                                FILE="$MAIN_DIR/go-quai/nodelogs/zone-1-1.log"
+                                ;;
+                            10)
+                                FILE="$MAIN_DIR/go-quai/nodelogs/zone-1-2.log"
+                                ;;
+                            11)
+                                FILE="$MAIN_DIR/go-quai/nodelogs/zone-2-0.log"
+                                ;;
+                            12)
+                                FILE="$MAIN_DIR/go-quai/nodelogs/zone-2-1.log"
+                                ;;
+                            13)
+                                FILE="$MAIN_DIR/go-quai/nodelogs/zone-2-2.log"
+                                ;;
+                        esac
+                        result=`tail -40 $FILE`
+                        dialog --cr-wrap --title "$FILE" --no-collapse --msgbox "\n$result" 30 90
+                        ;;
+                    1) clear;;
+                    255) clear;;
+                esac
+            fi
+        ;;
+        2 )
+            #If manager is running, redirect back to menu
+            if [ $ISMINING = "True" ]; then
+                dialog --title "Alert" \
+                --no-collapse \
+                --msgbox  "\nManager is already running." 0 0
+            elif [ $ISRUNNING = "False" ]; then
+                dialog --title "Alert" \
+                --no-collapse \
+                --msgbox  "\nPlease start your Node before starting the Manager." 0 0
+            else
+                REGION=$(dialog --nocancel --menu "Which regiond would you like to mine?" 0 0 3 \
+                    1 "Cyprus" \
+                    2 "Paxos" \
+                    3 "Hydra" 3>&1 1>&2 2>&3 3>&- )
+                ZONE=$(dialog --nocancel --menu "Which region would you like to mine?" 0 0 3 \
+                    1 "Zone-0" \
+                    2 "Zone-1" \
+                    3 "Zone-2" 3>&1 1>&2 2>&3 3>&- )
+
+                # Start go-quai
+                REGION=$(($REGION-1))
+                ZONE=$(($ZONE-1))
+                cd $HOME/$MAIN_DIR/quai-manager && make run-mine-background region=$REGION zone=$ZONE
+
+                dialog --title "Alert" \
+                --no-collapse \
+                --msgbox  "Manager started in: \nRegion: $REGION \nZone: $ZONE" 0 0
+                
+                # Ask the user if they would like to view nodelogs
+                dialog --title "Alert" \
+                --no-collapse \
+                --yesno  "\nManager started. Would you like to view the last 40 lines of your miner logs?" 0 0
+                response=$?
+                case $response in
+                    0) 
+                        # Print nodelogs
+                        cd
+                        result=`tail -40 $MAIN_DIR/quai-manager/logs/quai-manager.log`
+                        dialog --cr-wrap --title "$MAIN_DIR/quai-manger/logs/quai-manager.log" --msgbox "\n$result" 30 90
+                        ;;
+                    1) clear;;
+                    255) clear;;
+                esac
+            fi
+        ;;
+        3 )
+            # Verify the user wants to stop their node and manager
+            dialog --title "Alert" --yesno "\nAre you sure you want to stop the Node and/or Manager?" 0 0
+            response=$?
+            STOP="False"
+            case $response in
+                0) STOP="True";;
+                1) STOP="False";;
+                255) STOP="False";;
             esac
-            result=`tail -40 $FILE`
-            dialog --cr-wrap --title "$FILE" --msgbox "\n$result" 0 0
-        fi
-      ;;
-    7 )
-        if [ $MININGLOGS = "False"]; then
-            dialog --title "Alert" \
+            if [ $STOP = "True" ]; then
+                #If user chooses stop, kill node
+                cd $HOME/$MAIN_DIR/quai-manager
+                make stop>/dev/null 2>&1
+                cd $HOME/$MAIN_DIR/go-quai
+                make stop>/dev/null 2>&1 | \
+                dialog --title "Stop" \
+                --no-collapse \
+                --infobox "\nStopping Node and/or Manager. Please wait."  0 0
+                dialog --title "Stop" \
+                --no-cancel \
+                --msgbox "\nNode and/or Manager stopped. Press OK to return to the menu." 0 0
+            fi
+        ;;
+        4 )
+            # Update go-quai
+            cd $HOME/$MAIN_DIR/go-quai
+            git pull>/dev/null 2>&1 | \
+            dialog --title "Update" \
             --no-collapse \
-            --msgbox "\nPlease start your manager before viewing manager logs." 0 0
-        else
-            # Print Miner Logs
-            cd
-            dialog --nocancel --pause "This will show the last 40 lines of your miner logs. Press OK to continue." 10 40 2
-            result=`tail -40 quainetwork/quai-manager/logs/quai-manager.log`
-            dialog --cr-wrap --title "quainetwork/quai-manager/logs/quai-manager.log" --msgbox "\n$result" 30 90
-        fi
-      ;;
+            --infobox "\nUpdating Node. Please wait."  7 28
+
+            make go-quai>/dev/null 2>&1 | \
+            dialog --title "Update" \
+            --no-collapse \
+            --infobox "\nUpdating Node. Please wait."  7 28
+            
+            dialog --title "Update" \
+            --no-collapse \
+            --msgbox "\nNode updated. Press OK to continue." 7 28
+
+            # Update quai-manager
+            cd $HOME/$MAIN_DIR/quai-manager 
+            git pull>/dev/null 2>&1 | \
+            dialog --title "Update" \
+            --no-collapse \
+            --infobox "\nUpdating Manager. Please wait."  7 28
+            
+            make quai-manager>/dev/null 2>&1 | \
+            dialog --title "Update" \
+            --no-collapse \
+            --infobox "\nUpdating Manager. Please wait."  7 28
+            
+            dialog --title "Update" \
+            --no-collapse \
+            --msgbox "\nManager updated. Press OK to return to the menu." 0 0
+        ;;
+        5 )
+            if [ $NODELOGS = "False" ]; then
+                dialog --title "Alert" \
+                --no-collapse \
+                --msgbox "\nPlease start your node before viewing nodelogs." 0 0
+            else
+                #Print nodelogs
+                cd $HOME
+                LOCATION=$(dialog --nocancel --menu "In which location would you like to view nodelogs?" 0 0 13 \
+                        1 "Prime" \
+                        2 "Cyprus" \
+                        3 "Paxos" \
+                        4 "Hydra" \
+                        5 "Cyprus-1" \
+                        6 "Cyprus-2" \
+                        7 "Cyprus-3" \
+                        8 "Paxos-1" \
+                        9 "Paxos-2" \
+                        10 "Paxos-3" \
+                        11 "Hydra-1" \
+                        12 "Hydra-2" \
+                        13 "Hydra-3" 3>&1 1>&2 2>&3 3>&- )
+                case $LOCATION in
+                    1) 
+                        FILE="$MAIN_DIR/go-quai/nodelogs/prime.log"
+                        ;;
+                    2)
+                        FILE="$MAIN_DIR/go-quai/nodelogs/region-0.log"
+                        ;;
+                    3)
+                        FILE="$MAIN_DIR/go-quai/nodelogs/region-1.log"
+                        ;;
+                    4)
+                        FILE="$MAIN_DIR/go-quai/nodelogs/region-2.log"
+                        ;;
+                    5)
+                        FILE="$MAIN_DIR/go-quai/nodelogs/zone-0-0.log"
+                        ;;
+                    6)
+                        FILE="$MAIN_DIR/go-quai/nodelogs/zone-0-1.log"
+                        ;;
+                    7)
+                        FILE="$MAIN_DIR/go-quai/nodelogs/zone-0-2.log"
+                        ;;
+                    8)
+                        FILE="$MAIN_DIR/go-quai/nodelogs/zone-1-0.log"
+                        ;;
+                    9)
+                        FILE="$MAIN_DIR/go-quai/nodelogs/zone-1-1.log"
+                        ;;
+                    10)
+                        FILE="$MAIN_DIR/go-quai/nodelogs/zone-1-2.log"
+                        ;;
+                    11)
+                        FILE="$MAIN_DIR/go-quai/nodelogs/zone-2-0.log"
+                        ;;
+                    12)
+                        FILE="$MAIN_DIR/go-quai/nodelogs/zone-2-1.log"
+                        ;;
+                    13)
+                        FILE="$MAIN_DIR/go-quai/nodelogs/zone-2-2.log"
+                        ;;
+                esac
+                result=`tail -40 $FILE`
+                dialog --cr-wrap --title "$FILE" --msgbox "\n$result" 0 0
+            fi
+        ;;
+        6 )
+            if [ $MININGLOGS = "False"]; then
+                dialog --title "Alert" \
+                --no-collapse \
+                --msgbox "\nPlease start your manager before viewing manager logs." 0 0
+            else
+                # Print Miner Logs
+                cd
+                result=`tail -40 $MAIN_DIR/quai-manager/logs/quai-manager.log`
+                dialog --cr-wrap --title "$MAIN_DIR/quai-manager/logs/quai-manager.log" --msgbox "\n$result" 30 90
+            fi
+        ;;
   esac
 done

--- a/quai.sh
+++ b/quai.sh
@@ -73,7 +73,7 @@ else
             #Inform user node is installed
             dialog --title "Installation" \
             --no-collapse \
-            --msgbox "\nNode installed. Press OK to continue." 7 28
+            --msgbox "\nNode installed.\n \nPress OK to continue." 7 28
 
             #Configure go-quai
             cd $HOME/$MAIN_DIR/go-quai
@@ -81,46 +81,36 @@ else
             make go-quai>/dev/null 2>&1 | 
             dialog --title "Installation" \
             --no-collapse \
-            --infobox "\nGenerating binaries. Please wait. " 7 28
-
-            # Ask user to input wallet addresses and replace them in the network.env file
-            dialog --title "Installation" \
-            --no-collapse \
-            --msgbox "\nPlease enter your 13 Quai addresses. Press OK to continue." 0 0
-            
-            ## Placeholder for new copy paste network.env thing
-            dialog --title "Installation" \
-            --no-collapse \
-            --msgbox "\nPLACEHOLDER" 0 0
+            --infobox "\nGenerating binaries.\n \nPlease wait. " 7 28
 
             #Inform user node is configured
             dialog --title "Installation" \
             --no-collapse \
-            --msgbox "\nNode and mining addresses configured. Press OK to continue." 0 0
+            --msgbox "\nNode configured.\n \nPress OK to continue." 0 0
 
             # Clone into quai-manager
             cd $HOME/$MAIN_DIR
             git clone https://github.com/dominant-strategies/quai-manager>/dev/null 2>&1 | \
             dialog --title "Installation" \
             --no-collapse \
-            --infobox "\nInstalling Manager. Please wait."  7 28
+            --infobox "\nInstalling Manager.\n \nPlease wait."  7 28
             
             #Inform user manager is installed
             dialog --title "Installation" \
             --no-collapse \
-            --msgbox "\nManager installed. Press OK to continue." 7 28
+            --msgbox "\nManager installed.\n \nPress OK to continue." 7 28
 
             #Configure quai-manager
             cd $HOME/$MAIN_DIR/quai-manager
             make quai-manager>/dev/null 2>&1 | \
             dialog --title "Installation" 
             --no-collapse \
-            --infobox "\nGenerating binaries. Please wait. " 7 28
+            --infobox "\nGenerating binaries.\n \nPlease wait. " 7 28
 
             #Inform user manager is configured
             dialog --title "Installation" \
             --no-collapse \
-            --msgbox "\nManager configured. Installation complete." 0 0
+            --msgbox "\nManager configured.\n \nInstallation complete." 0 0
             ;;
         1) 
             echo "Installation cancelled."
@@ -183,7 +173,7 @@ while true; do
     case $exit_status in
         $DIALOG_CANCEL)
         # Verify the user wants to stop their node and manager
-        dialog --title "Alert" --yesno "\nExit the program? This will stop your node and miner." 0 0
+        dialog --title "Alert" --yesno "\nExit the Quai Hardware Manager?\n \n\Z1This will stop your node and miner.\Zn" 0 0
         response=$?
         EXIT="False"
         case $response in
@@ -199,15 +189,15 @@ while true; do
             make stop>/dev/null 2>&1 | \
             dialog --title "Stop" \
             --no-collapse \
-            --infobox "\nStopping Node and/or Manager. Please wait."  0 0
+            --infobox "\nStopping Node and/or Manager.\n \nPlease wait."  0 0
             clear
-            echo "Program terminated."
+            echo "Quai Hardware Manager stopped."
             exit
         fi
         ;;
         $DIALOG_ESC)
         # Verify the user wants to stop their node and manager
-        dialog --yesno "\nExit the program? This will stop your node and miner." 0 0
+        dialog --title "Alert" --yesno "\nExit the Quai Hardware Manager?\n \n\Z1This will stop your node and miner.\Zn" 0 0
         response=$?
         EXIT="False"
         case $response in
@@ -225,7 +215,7 @@ while true; do
             --no-collapse \
             --infobox "\nStopping Node and/or Manager. Please wait."  0 0
             clear
-            echo "Program terminated."
+            echo "Quai Hardware Manager stopped."
             exit
         fi
         ;;


### PR DESCRIPTION
After some user testing on a Linux Distro, some issues were found with the script. The following changes have been made to address issues:
- Fix README.md to specify executable permissions and discontinue the use of the sh command
- Refactor all boolean checks to work better on non-MacOS systems
- Remove `use_scrollbar` variable definition in `.dialogrc` as it was causing issues across different available dialog versions
- Remove check icon in main menu as it was not rendering correctly on Linux Distros
- Move to `pkill -f quai` for stop statements for better response time
- Remove direct setting of `ISMINING` and `ISRUNNING` for better responsiveness

TODO:
- Remove pause introduced after stopping manager and node
- Rename process to not include quai (causing issues with infinite looping when stopping processes)
- Final testing on both Linux and Mac machines to ensure all changes work correctly